### PR TITLE
fix: track initial unlock for lockuplinear using envio

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ The **~Flow-Envio** indexer watches over the core flow functionality of Sablier.
 > [disabling corepack](https://stackoverflow.com/questions/78795659/how-to-disable-auto-setting-of-packagemanager-when-corepack-is-enabled#comment138977943_78822612)
 > to avoid the warning. It looks like it's being [deprecated](https://www.youtube.com/watch?v=I7qMwaxNNOc) anyway.
 
-<sub>Version Trigger: [22]</sub>
+<sub>Version Trigger: [23]</sub>

--- a/apps/lockup-envio/pnpm-lock.yaml
+++ b/apps/lockup-envio/pnpm-lock.yaml
@@ -127,11 +127,11 @@ importers:
         specifier: 11.1.3
         version: 11.1.3
       rescript-envsafe:
-        specifier: 5.0.0
-        version: 5.0.0(rescript-schema@9.1.0(rescript@11.1.3))(rescript@11.1.3)
+        specifier: 4.2.0
+        version: 4.2.0(rescript-schema@8.1.0(rescript@11.1.3))(rescript@11.1.3)
       rescript-schema:
-        specifier: 9.1.0
-        version: 9.1.0(rescript@11.1.3)
+        specifier: 8.1.0
+        version: 8.1.0(rescript@11.1.3)
       root:
         specifier: ../.
         version: link:..
@@ -2271,11 +2271,16 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  rescript-envsafe@5.0.0:
-    resolution: {integrity: sha512-xSQbNsFSSQEynvLWUYtI7GJJhzicACLTq5aO1tjgK0N2Vcm9qlrkcLSmnU8tTohebEu9zgm1V/xYY+oGeQgLvA==}
+  rescript-envsafe@4.2.0:
+    resolution: {integrity: sha512-EpoEkyFzYZa2xzvOwHMAeW/dagqN0WXTL03IBJuZlE+33baKSTQEQ60L20472fPTJRxYaDv14A0UXglPvhSDsA==}
     peerDependencies:
       rescript: 11.x
-      rescript-schema: 9.x
+      rescript-schema: 6.x || 7.x || 8.x
+
+  rescript-schema@8.1.0:
+    resolution: {integrity: sha512-syU4Wvy2tJzBKkqa8ad1yYSDIh8EoKGUsZv6Wa0YpERqb7H6Kemtc6zU+BxIghahzShb6L7RMfVNuKC48KluIg==}
+    peerDependencies:
+      rescript: 11.x
 
   rescript-schema@9.1.0:
     resolution: {integrity: sha512-zD6hpg59HF6QJ3rnmhFV6mYtbfUd6ZTu20osL93aR9fdc3GTIX6N8Fy/6btgZ9a35A2NAzTvCgh/dz3EK7qfAw==}
@@ -5287,10 +5292,14 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  rescript-envsafe@5.0.0(rescript-schema@9.1.0(rescript@11.1.3))(rescript@11.1.3):
+  rescript-envsafe@4.2.0(rescript-schema@8.1.0(rescript@11.1.3))(rescript@11.1.3):
     dependencies:
       rescript: 11.1.3
-      rescript-schema: 9.1.0(rescript@11.1.3)
+      rescript-schema: 8.1.0(rescript@11.1.3)
+
+  rescript-schema@8.1.0(rescript@11.1.3):
+    dependencies:
+      rescript: 11.1.3
 
   rescript-schema@9.1.0(rescript@11.1.3):
     dependencies:

--- a/apps/lockup-envio/src/helpers/stream.ts
+++ b/apps/lockup-envio/src/helpers/stream.ts
@@ -331,6 +331,7 @@ export async function createDynamicMergedStream(
 
     cancelable: event.params.commonParams[5],
     transferable: event.params.commonParams[6],
+    // eslint-disable-next-line no-control-regex
     shape: event.params.commonParams[8].replace(/\x00/g, ""),
   } satisfies Entity;
 
@@ -601,6 +602,7 @@ export async function createLinearMergedStream(
     startTime: timestamps.startTime,
     endTime: timestamps.endTime,
     duration: timestamps.duration,
+    // eslint-disable-next-line no-control-regex
     shape: event.params.commonParams[8].replace(/\x00/g, ""),
   } satisfies Entity;
 
@@ -620,6 +622,23 @@ export async function createLinearMergedStream(
       cliff: false,
       cliffAmount: undefined,
       cliffTime: undefined,
+    };
+  })() satisfies Entity;
+
+  /** --------------- */
+  const partInitial = (() => {
+    const initial = event.params.unlockAmounts[0];
+
+    if (initial !== 0n) {
+      return {
+        initial: true,
+        initialAmount: initial,
+      };
+    }
+
+    return {
+      initial: false,
+      initialAmount: undefined,
     };
   })() satisfies Entity;
 
@@ -648,6 +667,7 @@ export async function createLinearMergedStream(
     ...partCliff,
     ...partFees,
     ...partProxy,
+    ...partInitial,
   };
 
   return {
@@ -835,6 +855,7 @@ export async function createTranchedMergedStream(
 
     cancelable: event.params.commonParams[5],
     transferable: event.params.commonParams[6],
+    // eslint-disable-next-line no-control-regex
     shape: event.params.commonParams[8].replace(/\x00/g, ""),
   } satisfies Entity;
 


### PR DESCRIPTION
This pr aims to fix a small bug on envio where the initial unlock was not tracked for lockup linear streams.